### PR TITLE
GPT/Open AI integration

### DIFF
--- a/ben.py
+++ b/ben.py
@@ -1,7 +1,7 @@
+import os
 import discord
-import discord.ext
+from discord.ext import commands
 import openai
-import logging
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -13,7 +13,7 @@ intents.message_content = True
 bot = commands.Bot(command_prefix='!', intents=intents)
 
 @bot.command()
-async def benChat(ctx)
+async def benChat(ctx):
     completion = openai.Completion.create(
             model="text-ada-001",
             max_tokens=5,

--- a/ben.py
+++ b/ben.py
@@ -3,13 +3,32 @@ import discord
 from discord.ext import commands
 import openai
 from dotenv import load_dotenv
+import logging
 
+
+# Logging rec from the docs
+logger = logging.getLogger('discord')
+logger.setLevel(logging.INFO)
+
+handler = logging.FileHandler(filename='discord.log', encoding='utf-8', mode='w')
+handler.setFormatter(logging.Formatter('%(asctime)s:%(levelname)s:%(name)s: %(message)s'))
+logger.addHandler(handler)
+
+handler_console = logging.StreamHandler()
+handler_console.setLevel(logging.INFO)
+logger.addHandler(handler_console)
+
+# Load all the environment variables using ".env"
 load_dotenv()
 
+# OpenAI key from dotenv
 openai.api_key=os.environ.get("OPENAI_KEY")
 
+# Intents are what all the bot is allowed to do via privileged gateway
 intents = discord.Intents.default()
 intents.message_content = True
+
+#bot commands start with '!'
 bot = commands.Bot(command_prefix='!', intents=intents)
 
 @bot.command()
@@ -30,17 +49,6 @@ async def benDraw(ctx):
             )
     await ctx.send(image.data[0].url)
 
-# @bot.command()
-# async def benQuip(ctx):
-#     completion = openai.Completion.create(
-#             model="text-davinci-003",
-#             max_tokens=20,
-#             temperature=0.5,
-#             top_p=0.3,
-#             frequency_penalty=0.5,
-#             presence_penalty=0.0,
-#             prompt=ctx.message.content
-#             )
-#     await ctx.send(completion.choices[0].text)
-
+# Discord bot token from dotenv
+logger.info('Starting bot')
 bot.run(os.environ.get("TOKEN"))

--- a/ben.py
+++ b/ben.py
@@ -15,32 +15,32 @@ bot = commands.Bot(command_prefix='!', intents=intents)
 @bot.command()
 async def benChat(ctx):
     completion = openai.Completion.create(
-            model="text-ada-001",
-            max_tokens=5,
-            prompt=ctx.message
+            model="text-curie-001",
+            max_tokens=80,
+            prompt=ctx.message.content
             )
-    ctx.send(completion.choices[0].text)
+    await ctx.send(completion.choices[0].text)
 
 
 @bot.command()
 async def benDraw(ctx):
     image = openai.Image.create(
             size="512x512",
-            prompt=ctx.message
+            prompt=ctx.message.content
             )
-    ctx.send(image.data[0].url)
+    await ctx.send(image.data[0].url)
 
-@bot.command()
-async def benQuip(ctx):
-    completion = openai.Completion.create(
-            model="text-davinci-003",
-            max_tokens=60,
-            temperature=0.5,
-            top_p=0.3,
-            frequency_penalty=0.5,
-            presence_penalty=0.0,
-            prompt=ctx.message
-            )
-    ctx.send(completion.choices[0].text)
+# @bot.command()
+# async def benQuip(ctx):
+#     completion = openai.Completion.create(
+#             model="text-davinci-003",
+#             max_tokens=20,
+#             temperature=0.5,
+#             top_p=0.3,
+#             frequency_penalty=0.5,
+#             presence_penalty=0.0,
+#             prompt=ctx.message.content
+#             )
+#     await ctx.send(completion.choices[0].text)
 
 bot.run(os.environ.get("TOKEN"))

--- a/ben.py
+++ b/ben.py
@@ -5,7 +5,6 @@ import openai
 from dotenv import load_dotenv
 import logging
 
-
 # Logging rec from the docs
 logger = logging.getLogger('discord')
 logger.setLevel(logging.INFO)
@@ -32,20 +31,20 @@ intents.message_content = True
 bot = commands.Bot(command_prefix='!', intents=intents)
 
 @bot.command()
-async def benchat(ctx):
+async def benchat(ctx, *, arg):
     completion = openai.Completion.create(
             model="text-curie-001",
             max_tokens=80,
-            prompt=ctx.message.content
+            prompt=arg
             )
     await ctx.send(completion.choices[0].text)
 
 
 @bot.command()
-async def bendraw(ctx):
+async def bendraw(ctx, *, arg):
     image = openai.Image.create(
             size="512x512",
-            prompt=ctx.message.content
+            prompt=arg
             )
     await ctx.send(image.data[0].url)
 

--- a/ben.py
+++ b/ben.py
@@ -1,0 +1,46 @@
+import discord
+import discord.ext
+import openai
+import logging
+from dotenv import load_dotenv
+
+load_dotenv()
+
+openai.api_key=os.environ.get("OPENAI_KEY")
+
+intents = discord.Intents.default()
+intents.message_content = True
+bot = commands.Bot(command_prefix='!', intents=intents)
+
+@bot.command()
+async def benChat(ctx)
+    completion = openai.Completion.create(
+            model="text-ada-001",
+            max_tokens=5,
+            prompt=ctx.message
+            )
+    ctx.send(completion.choices[0].text)
+
+
+@bot.command()
+async def benDraw(ctx):
+    image = openai.Image.create(
+            size="512x512",
+            prompt=ctx.message
+            )
+    ctx.send(image.data[0].url)
+
+@bot.command()
+async def benQuip(ctx):
+    completion = openai.Completion.create(
+            model="text-davinci-003",
+            max_tokens=60,
+            temperature=0.5,
+            top_p=0.3,
+            frequency_penalty=0.5,
+            presence_penalty=0.0,
+            prompt=ctx.message
+            )
+    ctx.send(completion.choices[0].text)
+
+bot.run(os.environ.get("TOKEN"))

--- a/ben.py
+++ b/ben.py
@@ -32,7 +32,7 @@ intents.message_content = True
 bot = commands.Bot(command_prefix='!', intents=intents)
 
 @bot.command()
-async def benChat(ctx):
+async def benchat(ctx):
     completion = openai.Completion.create(
             model="text-curie-001",
             max_tokens=80,
@@ -42,7 +42,7 @@ async def benChat(ctx):
 
 
 @bot.command()
-async def benDraw(ctx):
+async def bendraw(ctx):
     image = openai.Image.create(
             size="512x512",
             prompt=ctx.message.content


### PR DESCRIPTION
Adding the openai package and making some very basic calls to one of the gpt3 models.
  * https://github.com/openai/openai-python
    * https://beta.openai.com/docs/api-reference/introduction and also the completion section

The bot decorator and the `*, arg` params allow for it to handle commands more easliy. Lets it grab the rest of the text after the command.

Command syntax is from here: https://discordpy.readthedocs.io/en/latest/ext/commands/commands.html#keyword-only-arguments